### PR TITLE
Redesign portfolio with monochrome theme and animated network background

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -16,6 +16,7 @@ import {ClientRouter} from 'astro:transitions';
 <!-- Global Metadata -->
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
+<meta name="theme-color" content="#ffffff"/>
 <link rel="icon" type="image/svg+xml" href="/geo.png"/>
 <meta name="generator" content={Astro.generator}/>
 <head>

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,11 +1,11 @@
 ---
-const { title, img, desc, url, badge, tags, target = "_blank" } = Astro.props;
+const { title, img, desc, url, badge, tags, target = "_blank", index = 0 } = Astro.props;
 import { Image } from "astro:assets";
 ---
 
-<div class="md:w-1/3 w-full">
+<div class="md:w-1/3 w-full reveal" style={`transition-delay: ${index * 60}ms`}>
   <a href={url} target={target}>
-    <div class="card bg-base-100 transition ease-in-out hover:shadow-xl mx-6 my-2 hover:scale-[102%]">
+    <div class="card glass-card transition-all duration-300 ease-out hover:shadow-xl hover:glow-primary-sm mx-6 my-2 hover:scale-[102%]">
       <Image width={750} hight={1333} format="webp" src={img} alt={title} />
       <div class="card-body">
         <h2 class="card-title">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,11 +2,8 @@
 const today = new Date();
 ---
 
-<footer class="footer footer-center block mb-5 pt-10">
-  <div class="pb-2">
+<footer class="footer footer-center block mb-5 pt-10 border-t" style="border-color: var(--grid-line)">
+  <div class="pb-2 pt-4 text-base-content/60 text-sm">
     &copy; {today.getFullYear()} Yan Zhang
   </div>
 </footer>
-<style>
-
-</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,5 @@
 <div
-  class="sticky lg:hidden top-0 z-30 flex h-16 w-full justify-center bg-opacity-90 backdrop-blur transition-all duration-100 bg-base-100 text-base-content shadow-sm"
+  class="sticky lg:hidden top-0 z-30 flex h-16 w-full justify-center backdrop-blur-md transition-all duration-100 bg-base-100/80 text-base-content shadow-[0_1px_0_0_var(--grid-line)]"
 >
   <div class="navbar">
     <div class="navbar-start">
@@ -10,7 +10,7 @@
       </label>
     </div>
     <div class="navbar-center">
-      <a class="btn btn-ghost normal-case text-xl" href="/">Yan's Portfolio</a>
+      <a class="btn btn-ghost normal-case text-xl transition-all duration-200 hover:text-glow hover:text-primary" href="/">Yan's Portfolio</a>
     </div>
     <div class="navbar-end"></div>
   </div>

--- a/src/components/HorizontalCard.astro
+++ b/src/components/HorizontalCard.astro
@@ -1,16 +1,17 @@
 ---
-const { title, img, desc, url, badge, tags, target = "_blank", video, video_title } = Astro.props;
+const { title, img, desc, url, badge, tags, target = "_blank", video, video_title, index = 0 } = Astro.props;
 import { Image } from "astro:assets";
 import { YouTube } from 'astro-embed';
 ---
 
 <div
-  class="rounded-lg bg-base-100 hover:shadow-xl transition ease-in-out hover:scale-[102%]"
+  class="rounded-lg glass-card hover:shadow-xl hover:glow-primary-sm transition-all duration-300 ease-out hover:scale-[102%] reveal"
+  style={`transition-delay: ${index * 60}ms`}
 >
   <a href={url} target={target}>
     <div class="hero-content flex-col md:flex-row">
       {
-        video ? <div style="width: 750px" class="max-w-full md:max-w-[12rem] rounded-lg"><YouTube
+        video ? <div style="width: 750px" class="max-w-full md:max-w-[12rem] rounded-lg ring-1 ring-primary/20"><YouTube
           id={video}
           posterQuality="max"
           title={video_title}

--- a/src/components/SideBar.astro
+++ b/src/components/SideBar.astro
@@ -8,16 +8,17 @@ const { sideBarActiveItemID } = Astro.props;
 
 <div class="drawer-side z-40">
   <label for="my-drawer" class="drawer-overlay"></label>
-  <aside class="px-2 pt-2 h-auto min-h-full w-[19rem] bg-base-200 text-base-content flex flex-col">
-    <div class="w-fit mx-auto mt-5 mb-6">
+  <aside class="px-2 pt-2 h-auto min-h-full w-[19rem] glass-card border-r-0 lg:border-r border-y-0 text-base-content flex flex-col" style="border-color: var(--grid-line)">
+    <div class="w-fit mx-auto mt-5 mb-4">
       <a href="/">
         <div class="avatar transition ease-in-out hover:scale-[102%] block m-auto">
-          <div class="w-[8.5rem]">
+          <div class="w-[8.5rem] rounded-full ring-1 ring-primary/30 ring-offset-2 ring-offset-base-200">
             <Image class="mask mask-circle" format="webp" width={300} height={300} src={yanImage} alt="Profile image" />
           </div>
         </div>
       </a>
     </div>
+    <div class="h-px w-full bg-gradient-to-r from-transparent via-primary/40 to-transparent mb-4"></div>
     <SideBarMenu sideBarActiveItemID={sideBarActiveItemID} />
     <SideBarFooter />
   </aside>

--- a/src/components/SideBarFooter.astro
+++ b/src/components/SideBarFooter.astro
@@ -5,7 +5,7 @@
 
 <div class="social-icons px-4 pb-5 pt-1 flex self-center justify-center sticky bottom-0 bg-base-200">
 
-    <a href="https://github.com/claudezss" target="_blank" class="mx-3" aria-label="Github" title="Github">
+    <a href="https://github.com/claudezss" target="_blank" class="mx-3 transition-all duration-200 hover:text-primary hover:scale-110 hover:drop-shadow-[0_0_6px_var(--glow-primary)]" aria-label="Github" title="Github">
         <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="24"
@@ -21,9 +21,9 @@
         </svg>
     </a>
     <a
-            href="https://www.linkedin.com/in/yan-zhang-a21428113/"
+            href="https://www.linkedin.com/in/yan-zhang-p-eng-a21428113/"
             target="_blank"
-            class="mx-3"
+            class="mx-3 transition-all duration-200 hover:text-primary hover:scale-110 hover:drop-shadow-[0_0_6px_var(--glow-primary)]"
             aria-label="Linkedin"
             title="Linkedin"
     >
@@ -43,7 +43,7 @@
     <a
             href="https://space.bilibili.com/6151386"
             target="_blank"
-            class="mx-3"
+            class="mx-3 transition-all duration-200 hover:text-primary hover:scale-110 hover:drop-shadow-[0_0_6px_var(--glow-primary)]"
             aria-label="Bilibili"
             title="Bilibili"
     >
@@ -122,7 +122,7 @@
     <a
             href="https://orcid.org/0000-0001-9867-4924"
             target="_blank"
-            class="mx-3"
+            class="mx-3 transition-all duration-200 hover:text-primary hover:scale-110 hover:drop-shadow-[0_0_6px_var(--glow-primary)]"
             aria-label="ORCID"
             title="ORCID"
     >

--- a/src/components/SideBarMenu.astro
+++ b/src/components/SideBarMenu.astro
@@ -1,14 +1,14 @@
 ---
 const { sideBarActiveItemID } = Astro.props;
-const activeClass = "bg-base-300"; // For primary color replace with `active` class
+const activeClass = "menu-active-glow"; // For primary color replace with `active` class
 ---
 
 <ul class="menu grow shrink menu-md overflow-y-auto">
-    <li><a class="py-3 text-base" id="home" href="/">Home</a></li>
-    <li><a class="py-3 text-base" id="award" href="/award/">Award</a></li>
-    <li><a class="py-3 text-base" id="project" href="/project/">Project</a></li>
-    <li><a class="py-3 text-base" id="blog" href="/blog/">Blog</a></li>
-    <li><a class="py-3 text-base" id="cv" href="/cv">CV</a></li>
+    <li><a class="py-3 text-base transition-colors duration-200 hover:bg-base-300/60 hover:text-primary" id="home" href="/">Home</a></li>
+    <li><a class="py-3 text-base transition-colors duration-200 hover:bg-base-300/60 hover:text-primary" id="award" href="/award/">Award</a></li>
+    <li><a class="py-3 text-base transition-colors duration-200 hover:bg-base-300/60 hover:text-primary" id="project" href="/project/">Project</a></li>
+    <li><a class="py-3 text-base transition-colors duration-200 hover:bg-base-300/60 hover:text-primary" id="blog" href="/blog/">Blog</a></li>
+    <li><a class="py-3 text-base transition-colors duration-200 hover:bg-base-300/60 hover:text-primary" id="cv" href="/cv">CV</a></li>
 </ul>
 
 <script define:vars={{ sideBarActiveItemID: sideBarActiveItemID, activeClass: activeClass }}>

--- a/src/components/cv/TimeLine.astro
+++ b/src/components/cv/TimeLine.astro
@@ -2,21 +2,21 @@
 const {position, company, startDate, endDate, logo} = Astro.props;
 ---
 
-<div class="flex">
+<div class="flex reveal reveal-left">
     <div class="education__time">
-        <span class="w-4 h-4 bg-primary block rounded-full mt-1" style="margin-top: 13px"></span>
-        <span class="education__line bg-primary block h-full w-[2px] translate-x-[7px]"></span>
+        <span class="w-4 h-4 bg-primary block rounded-full mt-1 glow-primary-sm" style="margin-top: 13px"></span>
+        <span class="education__line bg-gradient-to-b from-primary to-primary/20 block h-full w-[2px] translate-x-[7px]"></span>
     </div>
     <div class="experience__data bd-grid px-5">
         <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
                 <img src={logo}
-                     alt="Company Logo" class="w-12 h-12 rounded-full">
+                     alt="Company Logo" class="w-12 h-12 rounded-full ring-1 ring-base-300 transition-transform duration-300 hover:scale-105">
             </div>
             <div class="flex-1">
                 <h2 class="text-lg font-semibold">{position}</h2>
                 <p>{company}</p>
-                <p class="text-gray-600">From {startDate} - {endDate}</p>
+                <p class="text-base-content/60">From {startDate} - {endDate}</p>
                 <p class="my-2 text-justify">
                     <slot/>
                 </p>

--- a/src/layouts/AwardLayout.astro
+++ b/src/layouts/AwardLayout.astro
@@ -13,34 +13,36 @@ const displayDate = dayjs(pubDate).format("ll");
 import { Image } from "astro:assets";
 ---
 
-<BaseLayout title={title} description={description} image={heroImage}>
+<BaseLayout title={title} description={description} image={heroImage} dimBackground={true}>
   <main class="md:flex md:justify-center">
     <article class="prose prose-lg max-w-[750px] prose-img:mx-auto">
-      {
-        heroImage && (
-        <Image
-            width={750}
-            height={422}
-            format="webp"
-            src={heroImage}
-            alt={title}
-            class="w-full mb-6"
-          />
-        )
-      }
-      <h1 class="title my-2 text-4xl font-bold">{title}</h1>
-      {pubDate && <time>{displayDate}</time>}
-      <br />
-      {badge && <div class="badge badge-secondary my-1">{badge}</div>}
-      {
-        updatedDate && (
-          <div>
-            {" "}
-            Last updated on <time>{updatedDate}</time>{" "}
-          </div>
-        )
-      }
-      <div class="divider my-2"></div>
+      <div class="reveal">
+        {
+          heroImage && (
+          <Image
+              width={750}
+              height={422}
+              format="webp"
+              src={heroImage}
+              alt={title}
+              class="w-full mb-6 rounded-box ring-1 ring-base-300"
+            />
+          )
+        }
+        <h1 class="title my-2 text-4xl font-bold">{title}</h1>
+        {pubDate && <time>{displayDate}</time>}
+        <br />
+        {badge && <div class="badge badge-secondary my-1">{badge}</div>}
+        {
+          updatedDate && (
+            <div>
+              {" "}
+              Last updated on <time>{updatedDate}</time>{" "}
+            </div>
+          )
+        }
+        <div class="divider my-2"></div>
+      </div>
       <slot />
     </article>
   </main>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,18 +6,18 @@ import SideBar from "../components/SideBar.astro";
 
 import { SITE_TITLE, SITE_DESCRIPTION } from "../config";
 
-const { image, title = SITE_TITLE, description = SITE_DESCRIPTION, includeSidebar = true, sideBarActiveItemID } = Astro.props;
+const { image, title = SITE_TITLE, description = SITE_DESCRIPTION, includeSidebar = true, sideBarActiveItemID, dimBackground = false } = Astro.props;
 ---
 
 <!DOCTYPE html>
-<html lang="en" data-theme="lofi">
+<html lang="en" data-theme="gridtech">
   <head>
     <BaseHead title={title} description={description} image={image} />
   </head>
   <body>
     <div class="bg-base-100 drawer lg:drawer-open">
       <input id="my-drawer" type="checkbox" class="drawer-toggle" />
-      <div class="drawer-content bg-base-100">
+      <div class={`drawer-content bg-base-100 ${dimBackground ? "bg-circuit-subtle" : "bg-circuit"}`}>
         <Header title={SITE_TITLE} />
         <div class="md:flex md:justify-center">
           <main class="p-6 pt-10 lg:max-w-[900px] max-w-[100vw]">
@@ -28,5 +28,27 @@ const { image, title = SITE_TITLE, description = SITE_DESCRIPTION, includeSideba
       </div>
       {includeSidebar && <SideBar sideBarActiveItemID={sideBarActiveItemID} />}
     </div>
+    <script>
+      function initReveal() {
+        const els = document.querySelectorAll('.reveal:not(.is-visible)');
+        if (!('IntersectionObserver' in window)) {
+          els.forEach((el) => el.classList.add('is-visible'));
+          return;
+        }
+        const io = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                entry.target.classList.add('is-visible');
+                io.unobserve(entry.target);
+              }
+            });
+          },
+          { threshold: 0.15, rootMargin: '0px 0px -8% 0px' }
+        );
+        els.forEach((el) => io.observe(el));
+      }
+      document.addEventListener('astro:page-load', initReveal);
+    </script>
   </body>
 </html>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -13,34 +13,36 @@ const displayDate = dayjs(pubDate).format("ll");
 import { Image } from "astro:assets";
 ---
 
-<BaseLayout title={title} description={description} image={heroImage}>
+<BaseLayout title={title} description={description} image={heroImage} dimBackground={true}>
   <main class="md:flex md:justify-center">
     <article class="prose prose-lg max-w-[750px] prose-img:mx-auto">
-      {
-        heroImage && (
-        <Image
-            width={750}
-            height={422}
-            format="webp"
-            src={heroImage}
-            alt={title}
-            class="w-full mb-6"
-          />
-        )
-      }
-      <h1 class="title my-2 text-4xl font-bold">{title}</h1>
-      {pubDate && <time>{displayDate}</time>}
-      <br />
-      {badge && <div class="badge badge-secondary my-1">{badge}</div>}
-      {
-        updatedDate && (
-          <div>
-            {" "}
-            Last updated on <time>{updatedDate}</time>{" "}
-          </div>
-        )
-      }
-      <div class="divider my-2"></div>
+      <div class="reveal">
+        {
+          heroImage && (
+          <Image
+              width={750}
+              height={422}
+              format="webp"
+              src={heroImage}
+              alt={title}
+              class="w-full mb-6 rounded-box ring-1 ring-base-300"
+            />
+          )
+        }
+        <h1 class="title my-2 text-4xl font-bold">{title}</h1>
+        {pubDate && <time>{displayDate}</time>}
+        <br />
+        {badge && <div class="badge badge-secondary my-1">{badge}</div>}
+        {
+          updatedDate && (
+            <div>
+              {" "}
+              Last updated on <time>{updatedDate}</time>{" "}
+            </div>
+          )
+        }
+        <div class="divider my-2"></div>
+      </div>
       <slot />
     </article>
   </main>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -13,34 +13,36 @@ const displayDate = dayjs(pubDate).format("ll");
 import { Image } from "astro:assets";
 ---
 
-<BaseLayout title={title} description={description} image={heroImage}>
+<BaseLayout title={title} description={description} image={heroImage} dimBackground={true}>
   <main class="md:flex md:justify-center">
     <article class="prose prose-lg max-w-[750px] prose-img:mx-auto">
-      {
-        heroImage && (
-        <Image
-            width={750}
-            height={422}
-            format="webp"
-            src={heroImage}
-            alt={title}
-            class="w-full mb-6"
-          />
-        )
-      }
-      <h1 class="title my-2 text-4xl font-bold">{title}</h1>
-      {pubDate && <time>{displayDate}</time>}
-      <br />
-      {badge && <div class="badge badge-secondary my-1">{badge}</div>}
-      {
-        updatedDate && (
-          <div>
-            {" "}
-            Last updated on <time>{updatedDate}</time>{" "}
-          </div>
-        )
-      }
-      <div class="divider my-2"></div>
+      <div class="reveal">
+        {
+          heroImage && (
+          <Image
+              width={750}
+              height={422}
+              format="webp"
+              src={heroImage}
+              alt={title}
+              class="w-full mb-6 rounded-box ring-1 ring-base-300"
+            />
+          )
+        }
+        <h1 class="title my-2 text-4xl font-bold">{title}</h1>
+        {pubDate && <time>{displayDate}</time>}
+        <br />
+        {badge && <div class="badge badge-secondary my-1">{badge}</div>}
+        {
+          updatedDate && (
+            <div>
+              {" "}
+              Last updated on <time>{updatedDate}</time>{" "}
+            </div>
+          )
+        }
+        <div class="divider my-2"></div>
+      </div>
       <slot />
     </article>
   </main>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,10 +3,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout title = "404: Not Found" includeSidebar={false}>
-  <div class="text-center">
+  <div class="text-center reveal reveal-scale">
     <h1 class="text-9xl font-bold mb-4">🏝</h1>
-    <h1 class="text-9xl font-bold mb-2">404</h1>
+    <h1 class="text-9xl font-bold mb-2 text-glow text-primary">404</h1>
     <h3 class="text-2xl">The page you're looking for couldn't be found.</h3>
-    <a class="btn btn-accent mt-9" href="/">Home</a>
+    <a class="btn btn-primary glow-primary-sm hover:glow-primary transition-all duration-300 mt-9" href="/">Home</a>
   </div>
 </BaseLayout>

--- a/src/pages/award/[...page].astro
+++ b/src/pages/award/[...page].astro
@@ -14,18 +14,18 @@ const { page } = Astro.props;
 
 <BaseLayout title="Award" sideBarActiveItemID="award">
   <div class="mb-5">
-    <div class="text-3xl w-full font-bold">Award</div>
+    <div class="text-3xl w-full font-bold border-l-4 border-primary pl-3 reveal">Award</div>
   </div>
 
   {
     page.data.length === 0 ? (
-      <div class="bg-base-200 border-l-4 border-secondary w-full p-4 min-w-full">
+      <div class="glass-card border-l-4 border-secondary w-full p-4 min-w-full">
         <p class="font-bold">Sorry!</p>
         <p>There are no award to show at the moment. Check back later!</p>
       </div>
     ) : (
       <ul>
-        {page.data.map((award) => (
+        {page.data.map((award, i) => (
           <>
             <HorizontalCard
               title={award.data.title}
@@ -34,6 +34,7 @@ const { page } = Astro.props;
               url={"/award/" + award.id}
               target="_self"
               badge={award.data.badge}
+              index={i}
             />
             <div class="divider my-0" />
           </>
@@ -45,7 +46,7 @@ const { page } = Astro.props;
   <div class="flex justify-between">
     {
       page.url.prev ? (
-        <a href={page.url.prev} class="btn btn-ghost my-10 mx-5">
+        <a href={page.url.prev} class="btn btn-ghost my-10 mx-5 hover:text-primary hover:glow-primary-sm transition-all duration-300">
           {" "}
           <svg
             class="h-6 w-6 fill-current md:h-8 md:w-8"
@@ -64,7 +65,7 @@ const { page } = Astro.props;
     }
     {
       page.url.next ? (
-        <a href={page.url.next} class="btn btn-ghost my-10 mx-5">
+        <a href={page.url.next} class="btn btn-ghost my-10 mx-5 hover:text-primary hover:glow-primary-sm transition-all duration-300">
           Older Projects{" "}
           <svg
             class="h-6 w-6 fill-current md:h-8 md:w-8"

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -26,23 +26,23 @@ const allTagsSet = Array.from(new Set(allTags)).sort();
 
 <BaseLayout title="Blog" sideBarActiveItemID="blog">
     <div class="mb-5">
-        <div class="text-3xl w-full font-bold">Blog</div>
+        <div class="text-3xl w-full font-bold border-l-4 border-primary pl-3 reveal">Blog</div>
     </div>
 
     <!-- Tag Filter Section -->
-    <div class="mb-6">
+    <div class="mb-6 reveal">
         <div class="text-lg font-semibold mb-3">Filter by tags:</div>
         <div class="flex flex-wrap gap-2 mb-4">
-            <button 
-                id="clear-filter" 
-                class="badge badge-primary cursor-pointer"
+            <button
+                id="clear-filter"
+                class="badge badge-primary cursor-pointer transition-colors duration-200"
             >
                 All Posts
             </button>
             {
                 allTagsSet.map(tag => (
-                    <button 
-                        class="badge badge-outline cursor-pointer tag-filter"
+                    <button
+                        class="badge badge-outline cursor-pointer tag-filter transition-colors duration-200"
                         data-tag={tag}
                     >
                         {tag}
@@ -56,13 +56,13 @@ const allTagsSet = Array.from(new Set(allTags)).sort();
     <div id="posts-container">
         {
             allPosts.length === 0 ? (
-                <div class="bg-base-200 border-l-4 border-secondary w-full p-4 min-w-full">
+                <div class="glass-card border-l-4 border-secondary w-full p-4 min-w-full">
                     <p class="font-bold">Sorry!</p>
                     <p>There are no blog posts to show at the moment. Check back later!</p>
                 </div>
             ) : (
                 <ul id="posts-list">
-                    {allPosts.map((post) => (
+                    {allPosts.map((post, i) => (
                         <li class="post-item" data-tags={post.data.tags.join(',')}>
                             <HorizontalCard
                                 title={post.data.title}
@@ -72,6 +72,7 @@ const allTagsSet = Array.from(new Set(allTags)).sort();
                                 tags={post.data.tags}
                                 target="_self"
                                 badge={post.data.badge}
+                                index={i}
                             />
                             <div class="divider my-0"/>
                         </li>
@@ -82,7 +83,7 @@ const allTagsSet = Array.from(new Set(allTags)).sort();
     </div>
 
     <!-- No Results Message -->
-    <div id="no-results" class="bg-base-200 border-l-4 border-secondary w-full p-4 min-w-full hidden">
+    <div id="no-results" class="glass-card border-l-4 border-secondary w-full p-4 min-w-full hidden">
         <p class="font-bold">No posts found</p>
         <p>Try selecting a different tag or view all posts.</p>
     </div>
@@ -98,16 +99,16 @@ const allTagsSet = Array.from(new Set(allTags)).sort();
             // Update button styles
             tagFilters.forEach(btn => {
                 if (btn.dataset.tag === selectedTag) {
-                    btn.className = 'badge badge-primary cursor-pointer tag-filter';
+                    btn.className = 'badge badge-primary cursor-pointer tag-filter transition-colors duration-200';
                 } else {
-                    btn.className = 'badge badge-outline cursor-pointer tag-filter';
+                    btn.className = 'badge badge-outline cursor-pointer tag-filter transition-colors duration-200';
                 }
             });
 
             if (selectedTag === '') {
-                clearFilter.className = 'badge badge-primary cursor-pointer';
+                clearFilter.className = 'badge badge-primary cursor-pointer transition-colors duration-200';
             } else {
-                clearFilter.className = 'badge badge-outline cursor-pointer';
+                clearFilter.className = 'badge badge-outline cursor-pointer transition-colors duration-200';
             }
 
             // Filter posts

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -24,18 +24,18 @@ const {posts} = Astro.props;
 
 <BaseLayout title="Blog" sideBarActiveItemID="blog">
     <div class="mb-5">
-        <div class="text-3xl w-full font-bold">Blog</div>
+        <div class="text-3xl w-full font-bold border-l-4 border-primary pl-3 reveal">Blog</div>
     </div>
 
     {
         posts.length === 0 ? (
-                <div class="bg-base-200 border-l-4 border-secondary w-full p-4 min-w-full">
+                <div class="glass-card border-l-4 border-secondary w-full p-4 min-w-full">
                     <p class="font-bold">Sorry!</p>
                     <p>There are no blog posts to show at the moment. Check back later!</p>
                 </div>
         ) : (
         <ul>
-            {posts.map((post) =>
+            {posts.map((post, i) =>
                     <>
                         <HorizontalCard
                                 title={post.data.title}
@@ -44,6 +44,7 @@ const {posts} = Astro.props;
                                 url={"/blog/" + post.id}
                                 target="_self"
                                 badge={post.data.badge}
+                                index={i}
                         />
                         <div class="divider my-0"/>
                     </>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -6,10 +6,10 @@ import TimeLineElement from "../components/cv/TimeLine.astro";
 <BaseLayout title="Resume" sideBarActiveItemID="cv">
 
     <div class="mb-5">
-        <div class="text-3xl w-full font-bold">Education</div>
+        <div class="text-3xl w-full font-bold border-l-4 border-primary pl-3 reveal">Education</div>
     </div>
 
-    <div class="time-line-container grid gap-4 mb-10">
+    <div class="time-line-container grid gap-6 mb-10">
         <TimeLineElement
                 position="Master of Engineering - MEng, ECE"
                 company="University of Toronto, Toronto, Canada"
@@ -27,7 +27,7 @@ import TimeLineElement from "../components/cv/TimeLine.astro";
     </div>
 
     <div class="mb-5">
-        <div class="text-3xl w-full font-bold">Experience</div>
+        <div class="text-3xl w-full font-bold border-l-4 border-primary pl-3 reveal">Experience</div>
     </div>
 
     <div class="time-line-container mb-10">
@@ -141,28 +141,16 @@ import TimeLineElement from "../components/cv/TimeLine.astro";
     </div>
 
     <div class="mb-5">
-        <div class="text-3xl w-full font-bold">Skills</div>
+        <div class="text-3xl w-full font-bold border-l-4 border-primary pl-3 reveal">Skills</div>
     </div>
 
-    <ul class="list-disc md:columns-5 columns-2 mx-6">
-        <li>Python</li>
-        <li>Pytorch</li>
-        <li>PYG</li>
-        <li>Ray.io</li>
-        <li>React</li>
-        <li>GAMS</li>
-        <li>AWS/GCP/Azure</li>
-        <li>flask/fastapi</li>
-        <li>Kafka</li>
-        <li>Docker</li>
-        <li>K8S</li>
-        <li>System Design</li>
-        <li>CI/CD</li>
-        <li>Power System</li>
-        <li>Optimization</li>
-        <li>Machine Learning</li>
-        <li>Github/Gitlab</li>
-        <li>AC OPF</li>
-        <li>Rust</li>
-    </ul>
+    <div class="flex flex-wrap gap-2 mx-6 mb-10 reveal">
+        {[
+            "Python", "Pytorch", "PYG", "Ray.io", "React", "GAMS", "AWS/GCP/Azure",
+            "flask/fastapi", "Kafka", "Docker", "K8S", "System Design", "CI/CD",
+            "Power System", "Optimization", "Machine Learning", "Github/Gitlab", "AC OPF", "Rust",
+        ].map((skill) => (
+            <div class="badge badge-outline transition-colors duration-200 hover:border-primary hover:text-primary">{skill}</div>
+        ))}
+    </div>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,6 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import HorizontalCard from "../components/HorizontalCard.astro";
 import { getCollection } from "astro:content";
-import { Image } from 'astro:assets'
 import paperImg from '../imgs/paper.png'
 
 const posts = (await getCollection("blog")).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
@@ -11,14 +10,29 @@ const projects = (await getCollection("project")).sort((a, b) => b.data.pubDate.
 const last_projects = projects.slice(0, 3);
 const awards = (await getCollection("award")).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 const last_awards = awards.slice(0, 3);
+
+const publications = [
+  {
+    title: "Three-Phase Distribution Locational Marginal Pricing for Competitive Electricity Markets with Distributed Generators and Flexible Loads",
+    desc: "2022 IEEE Power & Energy Society Innovative Smart Grid Technologies Conference (ISGT)",
+    url: "https://ieeexplore.ieee.org/abstract/document/9817498",
+    img: paperImg,
+  },
+  {
+    title: "Grid-Agent: An LLM-Powered Multi-Agent System for Power Grid Control",
+    desc: "ArXiv preprint",
+    url: "https://arxiv.org/abs/2508.05702",
+    img: paperImg,
+  },
+];
 ---
 
 <BaseLayout sideBarActiveItemID="home">
   <div class="pb-12 mt-5">
-    <div class="text-xl py-1">Hey there, I'M...</div><br/>
-    <div class="text-5xl font-bold">Yan (Claude) Zhang, P.Eng.</div> <br/>
-    <div class="text-3xl py-3 font-bold"> Senior Software Engineer, ML Engineer, Electrical Engineer</div>
-    <div class="py-2"><br/>
+    <div class="text-xl py-1 reveal">Hey there, I'M...</div><br/>
+    <div class="text-5xl font-bold text-glow reveal" style="transition-delay: 80ms">Yan (Claude) Zhang, P.Eng.</div> <br/>
+    <div class="text-3xl py-3 font-bold text-primary reveal" style="transition-delay: 160ms"> Senior Software Engineer, ML Engineer, Electrical Engineer</div>
+    <div class="py-2 reveal" style="transition-delay: 240ms"><br/>
       <text class="text-lg">
         Welcome to my portfolio website! I am a software engineer, ML engineer and electrical engineer,
         specializing in the dynamic realm of power systems. With a strong commitment to driving positive change,
@@ -26,17 +40,32 @@ const last_awards = awards.slice(0, 3);
         and energy-efficient future.
         </text>
     </div>
-    <div class="mt-8">
-      <a class="btn" href="https://www.linkedin.com/in/yan-zhang-a21428113/" target="_blank"> Let's connect!</a>
+    <div class="mt-8 reveal" style="transition-delay: 320ms">
+      <a class="btn btn-primary glow-primary-sm hover:glow-primary transition-all duration-300" href="https://www.linkedin.com/in/yan-zhang-p-eng-a21428113/" target="_blank"> Let's connect!</a>
+    </div>
+
+    <div class="stats stats-vertical sm:stats-horizontal glass-card mt-10 w-full reveal" style="transition-delay: 400ms">
+      <div class="stat">
+        <div class="stat-title">Years in Power Systems</div>
+        <div class="stat-value text-primary">7+</div>
+      </div>
+      <div class="stat">
+        <div class="stat-title">Publications</div>
+        <div class="stat-value text-secondary">2</div>
+      </div>
+      <div class="stat">
+        <div class="stat-title">DOE Prize Won</div>
+        <div class="stat-value text-accent">$50k</div>
+      </div>
     </div>
   </div>
 
   <div>
-    <div class="text-3xl w-full font-bold mb-2">Awards</div>
+    <div class="text-3xl w-full font-bold mb-2 border-l-4 border-primary pl-3 reveal">Awards</div>
   </div>
 
   {
-    last_awards.map((award) => (
+    last_awards.map((award, i) => (
         <>
           <HorizontalCard
               title={award.data.title}
@@ -45,6 +74,7 @@ const last_awards = awards.slice(0, 3);
               url={"/award/" + award.id}
               target="_self"
               badge={award.data.badge}
+              index={i}
           />
           <div class="divider my-0" />
         </>
@@ -52,11 +82,11 @@ const last_awards = awards.slice(0, 3);
   }
 
   <div>
-    <div class="text-3xl w-full font-bold mb-5 mt-10">Projects</div>
+    <div class="text-3xl w-full font-bold mb-5 mt-10 border-l-4 border-primary pl-3 reveal">Projects</div>
   </div>
 
   {
-    last_projects.map((project) => (
+    last_projects.map((project, i) => (
         <>
           <HorizontalCard
               title={project.data.title}
@@ -67,6 +97,7 @@ const last_awards = awards.slice(0, 3);
               badge={project.data.badge}
               video={project.data.video}
               video_title={project.data.video_title}
+              index={i}
           />
           <div class="divider my-0" />
         </>
@@ -74,11 +105,11 @@ const last_awards = awards.slice(0, 3);
   }
 
   <div>
-    <div class="text-3xl w-full font-bold mb-5 mt-10">Blogs</div>
+    <div class="text-3xl w-full font-bold mb-5 mt-10 border-l-4 border-primary pl-3 reveal">Blogs</div>
   </div>
 
   {
-    last_posts.map((post) => (
+    last_posts.map((post, i) => (
       <>
         <HorizontalCard
           title={post.data.title}
@@ -87,6 +118,7 @@ const last_awards = awards.slice(0, 3);
           url={"/blog/" + post.id}
           target="_self"
           badge={post.data.badge}
+          index={i}
         />
         <div class="divider my-0" />
       </>
@@ -94,58 +126,22 @@ const last_awards = awards.slice(0, 3);
   }
 
   <div>
-    <div class="text-3xl w-full font-bold mb-5 mt-10">Publications</div>
+    <div class="text-3xl w-full font-bold mb-5 mt-10 border-l-4 border-primary pl-3 reveal">Publications</div>
   </div>
-  <a href="https://ieeexplore.ieee.org/abstract/document/9817498" target="_blank">
-  <div class="rounded-lg bg-base-100 hover:shadow-xl transition ease-in-out hover:scale-[102%]">
-    <div class="hero-content flex-col md:flex-row">
-      <Image
-            src={paperImg}
-            width={750}
-            height={1333}
-            format="webp"
-            alt="paper"
-            class="max-w-full md:max-w-[13rem] rounded-lg"
-          />
-      <div class="grow w-full">
-        <h1 class="text-xl font-bold">
-          Three-Phase Distribution Locational Marginal Pricing for
-          Competitive Electricity Markets with Distributed Generators and Flexible Loads
-        </h1>
-        <p class="py-1 text-1xl">
-          2022 IEEE Power & Energy Society Innovative Smart Grid Technologies Conference (ISGT)
-        </p>
-        <div class="card-actions justify-end">
 
-        </div>
-      </div>
-
-    </div>
-  </div>
-  </a>
-  <a href="https://arxiv.org/abs/2508.05702" target="_blank">
-  <div class="rounded-lg bg-base-100 hover:shadow-xl transition ease-in-out hover:scale-[102%]">
-    <div class="hero-content flex-col md:flex-row">
-      <Image
-            src={paperImg}
-            width={750}
-            height={1333}
-            format="webp"
-            alt="paper"
-            class="max-w-full md:max-w-[13rem] rounded-lg"
-          />
-      <div class="grow w-full">
-        <h1 class="text-xl font-bold">
-          Grid-Agent: An LLM-Powered Multi-Agent System for Power Grid Control
-        </h1>
-
-        <div class="card-actions justify-end">
-
-        </div>
-      </div>
-
-    </div>
-  </div>
-  </a>
+  {
+    publications.map((pub, i) => (
+      <>
+        <HorizontalCard
+          title={pub.title}
+          img={pub.img}
+          desc={pub.desc}
+          url={pub.url}
+          index={i}
+        />
+        <div class="divider my-0" />
+      </>
+    ))
+  }
 
 </BaseLayout>

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -14,18 +14,18 @@ const { page } = Astro.props;
 
 <BaseLayout title="Project" sideBarActiveItemID="project">
   <div class="mb-5">
-    <div class="text-3xl w-full font-bold">Project</div>
+    <div class="text-3xl w-full font-bold border-l-4 border-primary pl-3 reveal">Project</div>
   </div>
 
   {
     page.data.length === 0 ? (
-      <div class="bg-base-200 border-l-4 border-secondary w-full p-4 min-w-full">
+      <div class="glass-card border-l-4 border-secondary w-full p-4 min-w-full">
         <p class="font-bold">Sorry!</p>
         <p>There are no project to show at the moment. Check back later!</p>
       </div>
     ) : (
       <ul>
-        {page.data.map((project) => (
+        {page.data.map((project, i) => (
           <>
             <HorizontalCard
               title={project.data.title}
@@ -34,6 +34,7 @@ const { page } = Astro.props;
               url={"/project/" + project.id}
               target="_self"
               badge={project.data.badge}
+              index={i}
             />
             <div class="divider my-0" />
           </>
@@ -45,7 +46,7 @@ const { page } = Astro.props;
   <div class="flex justify-between">
     {
       page.url.prev ? (
-        <a href={page.url.prev} class="btn btn-ghost my-10 mx-5">
+        <a href={page.url.prev} class="btn btn-ghost my-10 mx-5 hover:text-primary hover:glow-primary-sm transition-all duration-300">
           {" "}
           <svg
             class="h-6 w-6 fill-current md:h-8 md:w-8"
@@ -64,7 +65,7 @@ const { page } = Astro.props;
     }
     {
       page.url.next ? (
-        <a href={page.url.next} class="btn btn-ghost my-10 mx-5">
+        <a href={page.url.next} class="btn btn-ghost my-10 mx-5 hover:text-primary hover:glow-primary-sm transition-all duration-300">
           Older Projects{" "}
           <svg
             class="h-6 w-6 fill-current md:h-8 md:w-8"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,7 +1,158 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 @plugin "daisyui" {
-    themes: all;
+  themes: gridtech --default;
+}
+@plugin "daisyui/theme" {
+  name: "gridtech";
+  default: true;
+  prefersdark: false;
+  color-scheme: light;
+
+  --color-base-100: oklch(100% 0 0);
+  --color-base-200: oklch(97% 0 0);
+  --color-base-300: oklch(90% 0 0);
+  --color-base-content: oklch(15% 0 0);
+
+  --color-primary: oklch(15% 0 0);
+  --color-primary-content: oklch(98% 0 0);
+  --color-secondary: oklch(40% 0 0);
+  --color-secondary-content: oklch(98% 0 0);
+  --color-accent: oklch(58% 0 0);
+  --color-accent-content: oklch(98% 0 0);
+  --color-neutral: oklch(30% 0 0);
+  --color-neutral-content: oklch(97% 0 0);
+
+  --color-info: oklch(50% 0 0);
+  --color-info-content: oklch(97% 0 0);
+  --color-success: oklch(35% 0 0);
+  --color-success-content: oklch(97% 0 0);
+  --color-warning: oklch(65% 0 0);
+  --color-warning-content: oklch(15% 0 0);
+  --color-error: oklch(25% 0 0);
+  --color-error-content: oklch(97% 0 0);
+
+  --radius-selector: 0.5rem;
+  --radius-field: 0.5rem;
+  --radius-box: 1rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}
+
+:root {
+  --grid-line: color-mix(in oklch, var(--color-base-content) 12%, transparent);
+  --glow-primary: color-mix(in oklch, var(--color-primary) 30%, transparent);
+  --glow-secondary: color-mix(in oklch, var(--color-secondary) 30%, transparent);
+  --network-pattern: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='480' height='480' viewBox='0 0 480 480'%3E%3Cg fill='none' stroke='%23000000' stroke-width='1' opacity='0.10'%3E%3Cline x1='70' y1='90' x2='250' y2='60'/%3E%3Cline x1='250' y1='60' x2='410' y2='100'/%3E%3Cline x1='90' y1='250' x2='240' y2='230'/%3E%3Cline x1='240' y1='230' x2='400' y2='260'/%3E%3Cline x1='60' y1='410' x2='260' y2='400'/%3E%3Cline x1='260' y1='400' x2='420' y2='420'/%3E%3C/g%3E%3Cg fill='none' stroke='%23000000' stroke-width='1' opacity='0.07'%3E%3Cline x1='70' y1='90' x2='90' y2='250'/%3E%3Cline x1='90' y1='250' x2='60' y2='410'/%3E%3Cline x1='250' y1='60' x2='240' y2='230'/%3E%3Cline x1='240' y1='230' x2='260' y2='400'/%3E%3Cline x1='410' y1='100' x2='400' y2='260'/%3E%3Cline x1='400' y1='260' x2='420' y2='420'/%3E%3C/g%3E%3Cg fill='none' stroke='%23000000' stroke-width='1' opacity='0.05'%3E%3Cline x1='70' y1='90' x2='240' y2='230'/%3E%3Cline x1='250' y1='60' x2='90' y2='250'/%3E%3Cline x1='240' y1='230' x2='420' y2='420'/%3E%3C/g%3E%3Cg fill='%23000000' opacity='0.28'%3E%3Ccircle cx='70' cy='90' r='3'/%3E%3Ccircle cx='250' cy='60' r='3'/%3E%3Ccircle cx='410' cy='100' r='3'/%3E%3Ccircle cx='90' cy='250' r='3'/%3E%3Ccircle cx='240' cy='230' r='3.5'/%3E%3Ccircle cx='400' cy='260' r='3'/%3E%3Ccircle cx='60' cy='410' r='3'/%3E%3Ccircle cx='260' cy='400' r='3'/%3E%3Ccircle cx='420' cy='420' r='3'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+.bg-circuit {
+  position: relative;
+  background-color: var(--color-base-100);
+  background-image: var(--network-pattern);
+  background-size: 480px 480px;
+  background-repeat: repeat;
+  animation: network-float 40s ease-in-out infinite;
+}
+.bg-circuit::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 0%, color-mix(in oklch, var(--color-primary) 5%, transparent), transparent 55%);
+}
+
+.bg-circuit-subtle {
+  position: relative;
+  background-color: var(--color-base-100);
+  background-image:
+    linear-gradient(color-mix(in oklch, var(--color-base-100) 62%, transparent), color-mix(in oklch, var(--color-base-100) 62%, transparent)),
+    var(--network-pattern);
+  background-size: cover, 480px 480px;
+  background-repeat: no-repeat, repeat;
+  animation: network-float 40s ease-in-out infinite;
+}
+.bg-circuit-subtle::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 0%, color-mix(in oklch, var(--color-primary) 3%, transparent), transparent 55%);
+}
+
+@keyframes network-float {
+  0% { background-position: 0px 0px; }
+  50% { background-position: 26px 18px; }
+  100% { background-position: 0px 0px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .bg-circuit, .bg-circuit-subtle {
+    animation: none;
+  }
+}
+
+.glow-primary {
+  box-shadow: 0 0 0 1px var(--grid-line), 0 0 24px var(--glow-primary);
+}
+.glow-primary-sm {
+  box-shadow: 0 0 12px var(--glow-primary);
+}
+.text-glow {
+  text-shadow: 0 0 12px var(--glow-primary);
+}
+
+.glass-card {
+  background: color-mix(in oklch, var(--color-base-200) 65%, transparent);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--grid-line);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+.reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.reveal-left {
+  transform: translateX(-24px);
+}
+.reveal-left.is-visible {
+  transform: translateX(0);
+}
+.reveal-scale {
+  transform: scale(0.96);
+}
+.reveal-scale.is-visible {
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .reveal, .reveal-left, .reveal-scale {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
+.menu-active-glow {
+  position: relative;
+  background: color-mix(in oklch, var(--color-primary) 12%, transparent);
+  color: var(--color-primary);
+}
+.menu-active-glow::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--color-primary);
+  box-shadow: 0 0 8px var(--glow-primary);
 }
 
 .time-line-container>div:last-child .education__time>.education__line {


### PR DESCRIPTION
## Summary
- Replaces the stock light "lofi" daisyUI theme with a custom black/white/gray theme (no color hues anywhere — buttons, badges, timeline, stats, etc. all resolve to grayscale).
- Adds a subtle animated SVG background of interconnected nodes/lines (evokes both a power grid and a neural network, fitting for a power-systems/ML engineer's portfolio), gently drifting via CSS animation and respecting prefers-reduced-motion.
- Adds scroll-reveal fade/slide-in animations and hover polish (glow/elevation shadows, glassmorphism cards) across shared chrome (sidebar, header, footer) and content components (Card, HorizontalCard, CV timeline).
- Individual long-form pages (blog post / project / award detail) automatically get a dimmer background (bg-circuit-subtle) via a dimBackground prop on BaseLayout, so the pattern doesn't fight with reading.
- Refactors the homepage's hand-coded publication cards to reuse HorizontalCard, and converts the CV skills list into badge chips.
- Fixes a pre-existing hardcoded text-gray-600 in the CV timeline that didn't respect the theme.

## Test plan
- [x] Verified in browser (dev server) across Home, CV, Award/Project/Blog listing and detail pages, and 404, at both mobile and desktop viewports.
- [x] Confirmed scroll-reveal animations fire on first load and after client-side (View Transitions) navigation.
- [x] Confirmed KaTeX math and MDX/YouTube embed content remain legible.
- [x] Confirmed no console errors or failed network requests.
- [ ] Reviewer: eyeball the live preview once deployed to confirm the monochrome look reads as intended.
